### PR TITLE
Feat: Axios request interceptor + Fix: setAuthentication error on string

### DIFF
--- a/src/orm/axios.js
+++ b/src/orm/axios.js
@@ -5,6 +5,11 @@ export default class Axios {
     this.instance = http.axios || axios.create(http);
     this.setAuthentication(http.access_token);
 
+    this.instance.interceptors.request.use(
+      config => http.onRequest(config, this.instance),
+      error => http.onError(error, this.instance),
+    );
+
     this.instance.interceptors.response.use(
       response => http.onResponse(response, this.instance),
       error => http.onError(error, this.instance),
@@ -15,8 +20,7 @@ export default class Axios {
 
   setAuthentication(token) {
     if (!token) return;
-    const isFunction = typeof token 
-    "function";
+    const isFunction = typeof token === 'function';
     const tokenStr = isFunction ? token() : token;
 
     this.instance.defaults.headers.common['Authorization'] = `Bearer ${tokenStr}`;

--- a/src/support/interfaces.js
+++ b/src/support/interfaces.js
@@ -84,10 +84,20 @@ export const AxiosRequestConfig = {
   proxy: {},
 
   /**
+   * Default onRequest
+   * @param {object} config
+   * @param {Axios} Axios instance
+   */
+  onRequest(config, axios) {
+    return config;
+  },
+
+  /**
    * Default on Response
    * @param {object} response
+   * @param {Axios} axios instance
    */
-  onResponse(response) {
+  onResponse(response, axios) {
     return response.data;
   },
 
@@ -134,8 +144,9 @@ export const AxiosRequestConfig = {
   /**
    * Default on Error
    * @param {object} error
+   * @param {Axios} axios instance
    */
-  onError(error) {
+  onError(error, axios) {
     const { response } = error;
     const errorTypes = {
       401: this.onUnauthorised,


### PR DESCRIPTION
When using included Axios instance, now allow request interceptor in `http.onRequest`.

Fixed bug where `setAuthentication` would always try to call the passed in token as function, regardless of `token` parameter's type.