### PR TITLE
Feat: No longer stripping all but data by default onResponse interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ export const AxiosRequestConfig = {
    * @param {object} response
    */
   onResponse(response) {
-    return response.data;
+    return response;
   },
 
   /**

--- a/src/actions/Create.js
+++ b/src/actions/Create.js
@@ -22,7 +22,7 @@ export default class Create extends Action {
 
     this.onRequest(commit);
     request
-      .then(data => this.onSuccess(commit, model, data))
+      .then(response => this.onSuccess(commit, model, response))
       .catch(error => this.onError(commit, error))
 
     return request;
@@ -42,7 +42,7 @@ export default class Create extends Action {
    * @param {object} model
    * @param {object} data
    */
-  static onSuccess(commit, model, data) {
+  static onSuccess(commit, model, { data }) {
     commit('onSuccess')
     model.insertOrUpdate({
       data,

--- a/src/actions/Delete.js
+++ b/src/actions/Delete.js
@@ -18,7 +18,7 @@ export default class Delete extends Action {
 
     this.onRequest(model, params);
     request
-      .then(data => this.onSuccess(model, params, data))
+      .then(response => this.onSuccess(model, params, response))
       .catch(error => this.onError(model, params, error))
 
     return request;
@@ -45,7 +45,7 @@ export default class Delete extends Action {
    * @param {object} params
    * @param {object} data
    */
-  static onSuccess(model, params, data) {
+  static onSuccess(model, params, { data }) {
     model.delete({
       where: params.params.id || data.id,
     })

--- a/src/actions/Fetch.js
+++ b/src/actions/Fetch.js
@@ -18,7 +18,7 @@ export default class Fetch extends Action {
 
     this.onRequest(commit);
     request
-      .then(data => this.onSuccess(commit, model, data))
+      .then(response => this.onSuccess(commit, model, response))
       .catch(error => this.onError(commit, error))
 
     return request;
@@ -38,7 +38,7 @@ export default class Fetch extends Action {
    * @param {object} model
    * @param {object} data
    */
-  static onSuccess(commit, model, data) {
+  static onSuccess(commit, model, { data }) {
     commit('onSuccess')
     model.insertOrUpdate({
       data,

--- a/src/actions/Get.js
+++ b/src/actions/Get.js
@@ -18,7 +18,7 @@ export default class Get extends Action {
 
     this.onRequest(commit);
     request
-      .then(data => this.onSuccess(commit, model, data))
+      .then(response => this.onSuccess(commit, model, response))
       .catch(error => this.onError(commit, error))
 
     return request;
@@ -38,7 +38,7 @@ export default class Get extends Action {
    * @param {object} model
    * @param {object} data
    */
-  static onSuccess(commit, model, data) {
+  static onSuccess(commit, model, { data }) {
     commit('onSuccess')
     model.insertOrUpdate({
       data,

--- a/src/actions/Update.js
+++ b/src/actions/Update.js
@@ -23,8 +23,8 @@ export default class Update extends Action {
 
     this.onRequest(model, params);
     request
-      .then(data => this.onSuccess(model, params, data))
-      .catch(error => this.onError(model, params, error))
+      .then(response => this.onSuccess(model, params, response))
+      .catch(error => this.onError(model, params, error));
 
     return request;
   }
@@ -50,7 +50,7 @@ export default class Update extends Action {
    * @param {object} params
    * @param {object} data
    */
-  static onSuccess(model, params, data) {
+  static onSuccess(model, params, { data }) {
     model.update({
       where: params.params.id || data.id,
       data: merge({}, data, {

--- a/src/support/interfaces.js
+++ b/src/support/interfaces.js
@@ -88,7 +88,7 @@ export const AxiosRequestConfig = {
    * @param {object} response
    */
   onResponse(response) {
-    return response.data;
+    return response;
   },
 
   /**


### PR DESCRIPTION
Response context may be important when processing a response. The default onRequest interceptor no longer only returns response, which made e.g. the status code unvavilable in `.then()` after an action