### PR TITLE
Removed Bearer in the Authorization header 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ export const AxiosRequestConfig = {
 
   /**
    * Access Token Variable
+   * Could also be a function.
+   * Example: access_token: () => { return localStorage['token'] },
+   * This method is called on every action.
    */
   access_token: '',
 
@@ -203,7 +206,7 @@ User.$get({
   params: {
     id: 1
   }
-}); 
+});
 
 /**
  * @uri `/users`

--- a/src/orm/axios.js
+++ b/src/orm/axios.js
@@ -23,7 +23,7 @@ export default class Axios {
     const isFunction = typeof token === 'function';
     const tokenStr = isFunction ? token() : token;
 
-    this.instance.defaults.headers.common['Authorization'] = `Bearer ${tokenStr}`;
+    this.instance.defaults.headers.common['Authorization'] = tokenStr;
   }
 
   /**


### PR DESCRIPTION
I think this should be up to the user to set `Bearer` in his token or not.

Some libraries  add `Bearer` directly in the localStorage and same thing for some API response.

To prevent this:
```js
access_token: () => window.localStorage['auth._token.local'].replace('Bearer ', '')
```

I think vuex-axios should simply use the user's token as it.

What do you think about this ?