### PR TITLE
feat: adds configurable `persistBy` option

### DIFF
--- a/docs/guide/configurations.md
+++ b/docs/guide/configurations.md
@@ -135,6 +135,22 @@ In addition to [axios request options](https://github.com/axios/axios#request-co
 
   **See also**: [Transforming Data](usage.md#transforming-data)
 
+### `persistBy`
+
+- **Type**: `string`
+- **Default**: `'insertOrUpdate'`
+
+  > Since 0.9.3+
+
+  This option determines which Vuex ORM persist method should be called when Vuex ORM Axios attempts to save the response data to the store.
+
+  You can set this option to any one of the following string values:
+
+  - `create`
+  - `insert`
+  - `update`
+  - `insertOrUpdate` (default)
+
 ### `save`
 
 - **Type**: `boolean`

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -94,12 +94,19 @@ Vuex ORM Axios will automatically save this data to the store, and the users ent
 
 Under the hood, the plugin will persist data to the store by determining which records require inserting and which require updating. To accomplish this, the plugin passes data to the Vuex ORM `insertOrUpdate` model method. Therefore, only valid model attributes will be persisted to the store.
 
+As of 0.9.3+ you may configure Vuex ORM Axios to persist data using an alternative Vuex ORM persist method other than the default `insertOrUpdate`. For example, you can refresh entities by passing the `persistBy` option as `'create'` which will persist data using the model's `create` method:
+
+```js
+User.api().get('url', { persistBy: 'create' })
+```
+
 If you do not want to persist response data automatically, you can defer persistence by configuring the request with the `{ save: false }` option.
 
 **See also**:
 
 - [Deferring Persistence](#deferring-persistence)
-- [Vuex ORM - Insert or Update](https://vuex-orm.org/guide/data/inserting-and-updating.html#insert-or-update)
+- [Configurations - persistBy](configurations.md#persistby)
+- [Vuex ORM - Data - Inserting & Updating](https://vuex-orm.org/guide/data/inserting-and-updating.html#insert-or-update)
 
 ### Delete Requests
 

--- a/src/VuexORMAxios.ts
+++ b/src/VuexORMAxios.ts
@@ -1,7 +1,7 @@
 import { Model } from '@vuex-orm/core'
-import Components from './contracts/Components'
-import GlobalConfig from './contracts/GlobalConfig'
-import ModelMixin from './mixins/Model'
+import { Components } from './contracts/Components'
+import { GlobalConfig } from './contracts/Config'
+import { Model as ModelMixin } from './mixins/Model'
 
 export default class VuexORMAxios {
   /**
@@ -23,7 +23,7 @@ export default class VuexORMAxios {
   }
 
   /**
-   * Plug in features.
+   * Plug-in features.
    */
   plugin(): void {
     ModelMixin(this.model, this.config)

--- a/src/api/Request.ts
+++ b/src/api/Request.ts
@@ -13,7 +13,8 @@ export class Request {
    * The default config.
    */
   config: Config = {
-    save: true
+    save: true,
+    persistBy: 'insertOrUpdate'
   }
 
   /**

--- a/src/api/Request.ts
+++ b/src/api/Request.ts
@@ -1,9 +1,9 @@
 import { AxiosInstance, AxiosResponse } from 'axios'
 import { Model } from '@vuex-orm/core'
-import Config from '../contracts/Config'
-import Response from './Response'
+import { Config } from '../contracts/Config'
+import { Response } from './Response'
 
-export default class Request {
+export class Request {
   /**
    * The model class.
    */

--- a/src/api/Response.ts
+++ b/src/api/Response.ts
@@ -45,25 +45,25 @@ export class Response {
 
     if (!this.validateData(data)) {
       console.warn(
-        '[Vuex ORM Axios] The response data could not be saved to the store because it is not an object or an array. You might want to use `dataTransformer` option to handle non-array/object response before saving it to the store.'
+        '[Vuex ORM Axios] The response data could not be saved to the store ' +
+          'because it is not an object or an array. You might want to use ' +
+          '`dataTransformer` option to handle non-array/object response ' +
+          'before saving it to the store.'
       )
 
       return
     }
 
-    let method: PersistMethods = 'insertOrUpdate'
+    let method = this.config.persistBy as PersistMethods
 
-    if (typeof this.config.save === 'string') {
-      if (!this.validatePersistMethod(this.config.save)) {
-        console.warn(
-          '[Vuex ORM Axios] The "save" option provided is not a recognized ' +
-            'value. Must be either "create", "insert", "update" or "insertOrUpdate".'
-        )
+    if (!this.validatePersistMethod(method)) {
+      console.warn(
+        '[Vuex ORM Axios] The "persistBy" option configured is not a ' +
+          'recognized value. Response data will be persisted by the ' +
+          'default `insertOrUpdate` method.'
+      )
 
-        return
-      }
-
-      method = this.config.save
+      method = 'insertOrUpdate'
     }
 
     this.entities = await this.persist(method, { data })

--- a/src/contracts/Components.ts
+++ b/src/contracts/Components.ts
@@ -3,5 +3,3 @@ import { Model } from '@vuex-orm/core'
 export interface Components {
   Model: typeof Model
 }
-
-export default Components

--- a/src/contracts/Config.ts
+++ b/src/contracts/Config.ts
@@ -1,16 +1,18 @@
-import { AxiosRequestConfig, AxiosResponse } from 'axios'
+import { AxiosRequestConfig, AxiosInstance, AxiosResponse } from 'axios'
 import { Model, Record } from '@vuex-orm/core'
 
-export type PersistOption = 'create' | 'insert' | 'insertOrUpdate'
+export type PersistMethods = 'create' | 'insert' | 'update' | 'insertOrUpdate'
 
 export interface Config extends AxiosRequestConfig {
   dataKey?: string
   dataTransformer?: (response: AxiosResponse) => Record | Record[]
-  save?: boolean | PersistOption
+  save?: boolean | PersistMethods
   delete?: string | number | ((model: Model) => boolean)
   actions?: {
     [name: string]: any
   }
 }
 
-export default Config
+export interface GlobalConfig extends Config {
+  axios?: AxiosInstance
+}

--- a/src/contracts/Config.ts
+++ b/src/contracts/Config.ts
@@ -6,7 +6,8 @@ export type PersistMethods = 'create' | 'insert' | 'update' | 'insertOrUpdate'
 export interface Config extends AxiosRequestConfig {
   dataKey?: string
   dataTransformer?: (response: AxiosResponse) => Record | Record[]
-  save?: boolean | PersistMethods
+  save?: boolean
+  persistBy?: PersistMethods
   delete?: string | number | ((model: Model) => boolean)
   actions?: {
     [name: string]: any

--- a/src/contracts/Config.ts
+++ b/src/contracts/Config.ts
@@ -1,10 +1,12 @@
 import { AxiosRequestConfig, AxiosResponse } from 'axios'
 import { Model, Record } from '@vuex-orm/core'
 
+export type PersistOption = 'create' | 'insert' | 'insertOrUpdate'
+
 export interface Config extends AxiosRequestConfig {
   dataKey?: string
   dataTransformer?: (response: AxiosResponse) => Record | Record[]
-  save?: boolean
+  save?: boolean | PersistOption
   delete?: string | number | ((model: Model) => boolean)
   actions?: {
     [name: string]: any

--- a/src/contracts/GlobalConfig.ts
+++ b/src/contracts/GlobalConfig.ts
@@ -1,8 +1,0 @@
-import { AxiosInstance } from 'axios'
-import Config from './Config'
-
-export interface GlobalConfig extends Config {
-  axios?: AxiosInstance
-}
-
-export default GlobalConfig

--- a/src/index.cjs.ts
+++ b/src/index.cjs.ts
@@ -1,7 +1,7 @@
 import './types/vuex-orm'
 
-import Components from './contracts/Components'
-import GlobalConfig from './contracts/GlobalConfig'
+import { Components } from './contracts/Components'
+import { GlobalConfig } from './contracts/Config'
 import VuexORMAxios from './VuexORMAxios'
 
 export default {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
 import './types/vuex-orm'
 
-import Components from './contracts/Components'
-import GlobalConfig from './contracts/GlobalConfig'
-import Config from './contracts/Config'
-import Request from './api/Request'
-import Response from './api/Response'
+import { Components } from './contracts/Components'
+import { Config, GlobalConfig } from './contracts/Config'
+import { Request } from './api/Request'
+import { Response } from './api/Response'
 import VuexORMAxios from './VuexORMAxios'
 
 export { GlobalConfig, Config, Request, Response }

--- a/src/mixins/Model.ts
+++ b/src/mixins/Model.ts
@@ -1,12 +1,9 @@
 import { AxiosInstance } from 'axios'
 import { Model as BaseModel } from '@vuex-orm/core'
-import GlobalConfig from '../contracts/GlobalConfig'
-import Request from '../api/Request'
+import { GlobalConfig } from '../contracts/Config'
+import { Request } from '../api/Request'
 
-export default function Model(
-  model: typeof BaseModel,
-  config: GlobalConfig
-): void {
+export function Model(model: typeof BaseModel, config: GlobalConfig): void {
   /**
    * The api client.
    */

--- a/src/types/vuex-orm.ts
+++ b/src/types/vuex-orm.ts
@@ -1,7 +1,6 @@
 import { AxiosInstance } from 'axios'
-import GlobalConfig from '../contracts/GlobalConfig'
-import Config from '../contracts/Config'
-import Request from '../api/Request'
+import { Config, GlobalConfig } from '../contracts/Config'
+import { Request } from '../api/Request'
 
 declare module '@vuex-orm/core' {
   namespace Model {

--- a/test/feature/Response_PersistBy.spec.ts
+++ b/test/feature/Response_PersistBy.spec.ts
@@ -1,0 +1,141 @@
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { createStore, assertState, fillState } from 'test/support/Helpers'
+import { Model } from '@vuex-orm/core'
+
+describe('Feature - Response - PersistBy', () => {
+  let mock: MockAdapter
+
+  class User extends Model {
+    static entity = 'users'
+
+    static fields() {
+      return {
+        id: this.attr(null),
+        name: this.attr('')
+      }
+    }
+  }
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios)
+  })
+  afterEach(() => {
+    mock.reset()
+  })
+
+  it('can persist using "create" method', async () => {
+    mock.onGet('/api/users').reply(200, { id: 2, name: 'Jane Doe' })
+
+    const store = createStore([User])
+
+    fillState(store, {
+      users: {
+        1: { $id: '1', id: 1, name: 'John Doe' }
+      }
+    })
+
+    await User.api().get('/api/users', { persistBy: 'create' })
+
+    assertState(store, {
+      users: {
+        2: { $id: '2', id: 2, name: 'Jane Doe' }
+      }
+    })
+  })
+
+  it('can persist using "insert" method', async () => {
+    mock.onGet('/api/users').reply(200, { id: 2, name: 'Jane Doe' })
+
+    const store = createStore([User])
+
+    fillState(store, {
+      users: {
+        1: { $id: '1', id: 1, name: 'John Doe' }
+      }
+    })
+
+    await User.api().get('/api/users', { persistBy: 'insert' })
+
+    assertState(store, {
+      users: {
+        1: { $id: '1', id: 1, name: 'John Doe' },
+        2: { $id: '2', id: 2, name: 'Jane Doe' }
+      }
+    })
+  })
+
+  it('can persist using "update" method', async () => {
+    mock.onGet('/api/users').reply(200, { id: 1, name: 'Johnny Doe' })
+
+    const store = createStore([User])
+
+    fillState(store, {
+      users: {
+        1: { $id: '1', id: 1, name: 'John Doe' }
+      }
+    })
+
+    await User.api().get('/api/users', { persistBy: 'update' })
+
+    assertState(store, {
+      users: {
+        1: { $id: '1', id: 1, name: 'Johnny Doe' }
+      }
+    })
+  })
+
+  it('can persist using "insertOrUpdate" method', async () => {
+    mock.onGet('/api/users').reply(200, [
+      { id: 1, name: 'Johnny Doe' },
+      { id: 2, name: 'Jane Doe' }
+    ])
+
+    const store = createStore([User])
+
+    fillState(store, {
+      users: {
+        1: { $id: '1', id: 1, name: 'John Doe' }
+      }
+    })
+
+    await User.api().get('/api/users', { persistBy: 'insertOrUpdate' })
+
+    assertState(store, {
+      users: {
+        1: { $id: '1', id: 1, name: 'Johnny Doe' },
+        2: { $id: '2', id: 2, name: 'Jane Doe' }
+      }
+    })
+  })
+
+  it('warns the user of an invalid `save` option value', async () => {
+    const spy = jest.spyOn(console, 'warn')
+
+    spy.mockImplementation((x) => x)
+
+    createStore([User])
+
+    mock.onGet('/api/users').reply(200, {})
+    await User.api().get('/api/users', { persistBy: 'invalid' as any })
+
+    expect(console.warn).toHaveBeenCalledTimes(1)
+
+    spy.mockReset()
+    spy.mockRestore()
+  })
+
+  it('sets `isSaved` flag', async () => {
+    mock.onGet('/api/users').reply(200, { id: 1, name: 'John Doe' })
+
+    createStore([User])
+
+    const response = await User.api().get('/api/users', { save: false })
+
+    expect(response.isSaved).toBe(false)
+
+    await response.save()
+
+    expect(response.isSaved).toBe(true)
+  })
+})

--- a/test/feature/Response_PersistBy.spec.ts
+++ b/test/feature/Response_PersistBy.spec.ts
@@ -3,7 +3,7 @@ import MockAdapter from 'axios-mock-adapter'
 import { createStore, assertState, fillState } from 'test/support/Helpers'
 import { Model } from '@vuex-orm/core'
 
-describe('Feature - Response - PersistBy', () => {
+describe('Feature - Response - Persist By', () => {
   let mock: MockAdapter
 
   class User extends Model {
@@ -109,7 +109,7 @@ describe('Feature - Response - PersistBy', () => {
     })
   })
 
-  it('warns the user of an invalid `save` option value', async () => {
+  it('warns the user of an invalid option value', async () => {
     const spy = jest.spyOn(console, 'warn')
 
     spy.mockImplementation((x) => x)
@@ -123,19 +123,5 @@ describe('Feature - Response - PersistBy', () => {
 
     spy.mockReset()
     spy.mockRestore()
-  })
-
-  it('sets `isSaved` flag', async () => {
-    mock.onGet('/api/users').reply(200, { id: 1, name: 'John Doe' })
-
-    createStore([User])
-
-    const response = await User.api().get('/api/users', { save: false })
-
-    expect(response.isSaved).toBe(false)
-
-    await response.save()
-
-    expect(response.isSaved).toBe(true)
   })
 })

--- a/test/feature/Response_Save.spec.ts
+++ b/test/feature/Response_Save.spec.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
-import { createStore, assertState, fillState } from 'test/support/Helpers'
+import { createStore, assertState } from 'test/support/Helpers'
 import { Model } from '@vuex-orm/core'
 
 describe('Feature - Response - Save', () => {
@@ -59,107 +59,6 @@ describe('Feature - Response - Save', () => {
         1: { $id: '1', id: 1, name: 'John Doe' }
       }
     })
-  })
-
-  it('can persist using "create" as `save` option', async () => {
-    mock.onGet('/api/users').reply(200, { id: 2, name: 'Jane Doe' })
-
-    const store = createStore([User])
-
-    fillState(store, {
-      users: {
-        1: { $id: '1', id: 1, name: 'John Doe' }
-      }
-    })
-
-    await User.api().get('/api/users', { save: 'create' })
-
-    assertState(store, {
-      users: {
-        2: { $id: '2', id: 2, name: 'Jane Doe' }
-      }
-    })
-  })
-
-  it('can persist using "insert" as `save` option', async () => {
-    mock.onGet('/api/users').reply(200, { id: 2, name: 'Jane Doe' })
-
-    const store = createStore([User])
-
-    fillState(store, {
-      users: {
-        1: { $id: '1', id: 1, name: 'John Doe' }
-      }
-    })
-
-    await User.api().get('/api/users', { save: 'insert' })
-
-    assertState(store, {
-      users: {
-        1: { $id: '1', id: 1, name: 'John Doe' },
-        2: { $id: '2', id: 2, name: 'Jane Doe' }
-      }
-    })
-  })
-
-  it('can persist using "update" as `save` option', async () => {
-    mock.onGet('/api/users').reply(200, { id: 1, name: 'Johnny Doe' })
-
-    const store = createStore([User])
-
-    fillState(store, {
-      users: {
-        1: { $id: '1', id: 1, name: 'John Doe' }
-      }
-    })
-
-    await User.api().get('/api/users', { save: 'update' })
-
-    assertState(store, {
-      users: {
-        1: { $id: '1', id: 1, name: 'Johnny Doe' }
-      }
-    })
-  })
-
-  it('can persist using "insertOrUpdate" as `save` option', async () => {
-    mock.onGet('/api/users').reply(200, [
-      { id: 1, name: 'Johnny Doe' },
-      { id: 2, name: 'Jane Doe' }
-    ])
-
-    const store = createStore([User])
-
-    fillState(store, {
-      users: {
-        1: { $id: '1', id: 1, name: 'John Doe' }
-      }
-    })
-
-    await User.api().get('/api/users', { save: 'insertOrUpdate' })
-
-    assertState(store, {
-      users: {
-        1: { $id: '1', id: 1, name: 'Johnny Doe' },
-        2: { $id: '2', id: 2, name: 'Jane Doe' }
-      }
-    })
-  })
-
-  it('warns the user of an invalid `save` option value', async () => {
-    const spy = jest.spyOn(console, 'warn')
-
-    spy.mockImplementation((x) => x)
-
-    createStore([User])
-
-    mock.onGet('/api/users').reply(200, {})
-    await User.api().get('/api/users', { save: 'invalid' as any })
-
-    expect(console.warn).toHaveBeenCalledTimes(1)
-
-    spy.mockReset()
-    spy.mockRestore()
   })
 
   it('sets `isSaved` flag', async () => {

--- a/test/feature/Response_Save.spec.ts
+++ b/test/feature/Response_Save.spec.ts
@@ -102,6 +102,26 @@ describe('Feature - Response - Save', () => {
     })
   })
 
+  it('can persist using "update" as `save` option', async () => {
+    mock.onGet('/api/users').reply(200, { id: 1, name: 'Johnny Doe' })
+
+    const store = createStore([User])
+
+    fillState(store, {
+      users: {
+        1: { $id: '1', id: 1, name: 'John Doe' }
+      }
+    })
+
+    await User.api().get('/api/users', { save: 'update' })
+
+    assertState(store, {
+      users: {
+        1: { $id: '1', id: 1, name: 'Johnny Doe' }
+      }
+    })
+  })
+
   it('can persist using "insertOrUpdate" as `save` option', async () => {
     mock.onGet('/api/users').reply(200, [
       { id: 1, name: 'Johnny Doe' },
@@ -136,7 +156,7 @@ describe('Feature - Response - Save', () => {
     mock.onGet('/api/users').reply(200, {})
     await User.api().get('/api/users', { save: 'invalid' as any })
 
-    expect(console.warn).toHaveBeenCalled()
+    expect(console.warn).toHaveBeenCalledTimes(1)
 
     spy.mockReset()
     spy.mockRestore()

--- a/test/feature/Response_Save.spec.ts
+++ b/test/feature/Response_Save.spec.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
-import { createStore, assertState } from 'test/support/Helpers'
+import { createStore, assertState, fillState } from 'test/support/Helpers'
 import { Model } from '@vuex-orm/core'
 
 describe('Feature - Response - Save', () => {
@@ -59,6 +59,87 @@ describe('Feature - Response - Save', () => {
         1: { $id: '1', id: 1, name: 'John Doe' }
       }
     })
+  })
+
+  it('can persist using "create" as `save` option', async () => {
+    mock.onGet('/api/users').reply(200, { id: 2, name: 'Jane Doe' })
+
+    const store = createStore([User])
+
+    fillState(store, {
+      users: {
+        1: { $id: '1', id: 1, name: 'John Doe' }
+      }
+    })
+
+    await User.api().get('/api/users', { save: 'create' })
+
+    assertState(store, {
+      users: {
+        2: { $id: '2', id: 2, name: 'Jane Doe' }
+      }
+    })
+  })
+
+  it('can persist using "insert" as `save` option', async () => {
+    mock.onGet('/api/users').reply(200, { id: 2, name: 'Jane Doe' })
+
+    const store = createStore([User])
+
+    fillState(store, {
+      users: {
+        1: { $id: '1', id: 1, name: 'John Doe' }
+      }
+    })
+
+    await User.api().get('/api/users', { save: 'insert' })
+
+    assertState(store, {
+      users: {
+        1: { $id: '1', id: 1, name: 'John Doe' },
+        2: { $id: '2', id: 2, name: 'Jane Doe' }
+      }
+    })
+  })
+
+  it('can persist using "insertOrUpdate" as `save` option', async () => {
+    mock.onGet('/api/users').reply(200, [
+      { id: 1, name: 'Johnny Doe' },
+      { id: 2, name: 'Jane Doe' }
+    ])
+
+    const store = createStore([User])
+
+    fillState(store, {
+      users: {
+        1: { $id: '1', id: 1, name: 'John Doe' }
+      }
+    })
+
+    await User.api().get('/api/users', { save: 'insertOrUpdate' })
+
+    assertState(store, {
+      users: {
+        1: { $id: '1', id: 1, name: 'Johnny Doe' },
+        2: { $id: '2', id: 2, name: 'Jane Doe' }
+      }
+    })
+  })
+
+  it('warns the user of an invalid `save` option value', async () => {
+    const spy = jest.spyOn(console, 'warn')
+
+    spy.mockImplementation((x) => x)
+
+    createStore([User])
+
+    mock.onGet('/api/users').reply(200, {})
+    await User.api().get('/api/users', { save: 'invalid' as any })
+
+    expect(console.warn).toHaveBeenCalled()
+
+    spy.mockReset()
+    spy.mockRestore()
   })
 
   it('sets `isSaved` flag', async () => {

--- a/test/support/Helpers.ts
+++ b/test/support/Helpers.ts
@@ -7,9 +7,15 @@ import VuexORMAxios from '@/index'
 Vue.use(Vuex)
 
 interface Entities {
-  [name: string]: {
-    [id: string]: Record<string, any>
-  }
+  [name: string]: Elements
+}
+
+interface State {
+  data: Elements
+}
+
+interface Elements {
+  [id: string]: Record<string, any>
 }
 
 export function createStore(models: typeof Model[]): Store<any> {
@@ -47,4 +53,15 @@ export function createState(entities: Entities): any {
 
 export function assertState(store: Store<any>, entities: Entities): void {
   expect(store.state.entities).toEqual(createState(entities))
+}
+
+export function fillState(store: Store<any>, entities: Entities): void {
+  for (const entity in entities) {
+    store.commit(`entities/$mutate`, {
+      entity,
+      callback: (state: State) => {
+        state.data = entities[entity]
+      }
+    })
+  }
 }


### PR DESCRIPTION
Resolves #93

#### Type of PR:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Documentation
- [ ] Other, please describe:

#### Breaking changes:

- [x] No
- [ ] Yes

### Details

This PR adds a new optional `persistBy?: string` option to allow configuring a preferred method of persistence. The default value is `'insertOrUpdate'`.

In a nutshell, while [this issue comment](https://github.com/vuex-orm/plugin-axios/issues/93#issuecomment-613238938) explains the idea pretty well, the plugin option `persistBy` can be configured to override the default persistence behaviour. 

The signature for this options is: `'create' | 'insert' | 'update' | 'insertOrUpdate'`

Beyond that, the plugin will warn users of any invalid value configured and fallback to the default `insertOrUpdate` method.

> N.B. This PR intentionally publicises `getDataFromResponse` as discussed in a previous issue #112. I think it makes sense to allow users to still be able to retrieve data through configured requests when deferring persistence.